### PR TITLE
[SDKTOOLS-426] Include res folders in aapt

### DIFF
--- a/src/main/groovy/com/sagiantebi/multilib/tasks/SimpleTasksCreator.groovy
+++ b/src/main/groovy/com/sagiantebi/multilib/tasks/SimpleTasksCreator.groovy
@@ -223,6 +223,13 @@ public class SimpleTasksCreator {
                 }
             }
         }
+
+        data.androidVariant.allRawAndroidResources.files.each {
+            if (it.exists()) {
+                depResDirs.add(it.path)
+            }
+        }
+
         if (depResDirs.size() > 0) {
             depResDirs.each { s->
                 args.add("-S")


### PR DESCRIPTION
When including the `fairbid-sdk-tools` module within the `androidMultilibProguard {...}` configuration closure, we spotted that the obfuscation was not being successful.

The investigation pointed out that some library dependencies that the tools are using (i. e., `com.google.android.material:material:1.0.0`) include, not only code, but also external resources.
These resources were being processed, but not included in the end in the final `aapt` command.
This PR aims to fix this, by exploring these generated resources and adding them as arguments for `aapt`.

The fix has been tested and proved working by obfuscating all libraries and doing an integration with them.